### PR TITLE
replace compile with implementation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This library is available on JCenter [ ![Download](https://api.bintray.com/packa
 Add the dependency to your app and make sure to use the jcenter repository:
 
 ```groovy
-    compile 'de.mobilej:thinr:0.2.7'
+    implementation 'de.mobilej:thinr:0.2.7'
 ```
 
 ## Version History


### PR DESCRIPTION
When you try to install with compile it gives the following warning.

> Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
> It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
> Affected Modules: app  

The compile needs to be replace with  implementation in README
